### PR TITLE
Simple Fix for Glances v4 api support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ following parameters are defined:
 - changed from `StaticPlatform` to `DynamicPlatform` (for async reasons)
 - better error handling
 - logs
+### Version 1.0.3
+- changed load accessories from BatteryService to HumiditySensor
+### Version 1.0.4
+- changed load accessories from HumidityService to ServiceLabel
+- changed back to HumidityService
+### Version 1.0.5
+- removed cpu updated log
+### Version 1.0.6
+- updated dependencies
+- call v4 of glances API and fallback to v3
 
 
 Future plans:

--- a/README.md
+++ b/README.md
@@ -5,22 +5,24 @@
 This [Homebridge](https://homebridge.io/) plugin platform exposes the `temperature sensors`, `cpu load` and `memory load` from  [Glances Monitoring Tool](https://github.com/nicolargo/glances) as accessoires to homebridge.
 
 Installation
-```
+
+```typescript
 npm install -g homebridge-glances
 ```
 
 You need to install [Glances](https://github.com/nicolargo/glances) on your target system and start it in `server mode`, which is done via the paramater `-w`. Start the Glances server with your own configuration. See -> [Configuration Docs](https://glances.readthedocs.io/en/stable/config.html).
-You can also put aliases to you sensors there, so on default they have generic names like 'it3451' etc. 
+You can also put aliases to you sensors there, so on default they have generic names like 'it3451' etc.
 Following Plugins are supported:
+
 - sensors -> Temperature data
 - cpu -> Cpu load
 - mem -> Memory load
 
 *Annotation* : The cpu loads and memory loads are exposed as `HumidityService`, because the loads are in percent value, the `HumidityService.CurrentRelativeHumidity` characteristic was the best option for that.
 
-Example: 
+Example:
 
-```
+```text
 [sensors]
 #enable it
 disable=False 
@@ -40,59 +42,73 @@ disable=False
 ```
 
 ## Homebridge configuration
+
 To enable the platform in homebridge add the following to the config:
 
-```
+```json
 platforms:
 [
-	{
-		"name":  "Glances",
-		"platform":  "Glances",
-		"hostname":  "{IP},
-		"updateInterval":  3000,
-		"prefix":  "{PREFIX}",
-		"sensors": true,
-		"cpu": true,
-		"memory": true
-	}
+ {
+  "name":  "Glances",
+  "platform":  "Glances",
+  "hostname":  "{IP},
+  "updateInterval":  3000,
+  "prefix":  "{PREFIX}",
+  "sensors": true,
+  "cpu": true,
+  "memory": true
+ }
 ]
 ```
 
 following parameters are defined:
 
-| Property | Utilization | Default Value | Description 
-|--|--|--|--|
-| name | required | Glances| The name handled by homebridge |
-|platform|required|Glances|Required to identify the platform|
-|hostname|required||The ip or hostname of your target system where  glances server is running|
-|port|optional|61208|The port of your target system where glances server is running|
-|updateInterval|optional|5000|The update interval in milliseconds to update the sensors, **ATTENTION** values below 1000 may slow down your homebridge or target system|
-|prefix|optional||A prefix to identify the exposed accessories better|
-|sensors|optional|false|Enables the sensors plugin to be exposed|
-|cpu|optional|false|Enables the cpu plugin to be exposed|
-|memory|optional|false|Enables the memory plugin to be exposed|
+| Property | Utilization | Default Value | Description
+|--|--|--|--
+| name | required | Glances| The name handled by homebridge
+|platform|required|Glances|Required to identify the platform
+|hostname|required||The ip or hostname of your target system where  glances server is running
+|port|optional|61208|The port of your target system where glances server is running
+|updateInterval|optional|5000|The update interval in milliseconds to update the sensors, **ATTENTION** values below 1000 may slow down your homebridge or target system
+|prefix|optional||A prefix to identify the exposed accessories better
+|sensors|optional|false|Enables the sensors plugin to be exposed
+|cpu|optional|false|Enables the cpu plugin to be exposed
+|memory|optional|false|Enables the memory plugin to be exposed
 
 ## Release Notes
-### Version 1.0.0 
+
+### Version 1.0.0
+
 - Initial Version
+
 ### Version 1.0.1
+
 - Some small fixes
+
 ### Version 1.0.2
+
 - made it all asynch
 - changed from `StaticPlatform` to `DynamicPlatform` (for async reasons)
 - better error handling
 - logs
+
 ### Version 1.0.3
+
 - changed load accessories from BatteryService to HumiditySensor
+
 ### Version 1.0.4
+
 - changed load accessories from HumidityService to ServiceLabel
 - changed back to HumidityService
+
 ### Version 1.0.5
+
 - removed cpu updated log
+
 ### Version 1.0.6
+
 - updated dependencies
 - call v4 of glances API and fallback to v3
-
 
 Future plans:
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "name": "Michael Trinkies"
   },
   "dependencies": {
-    "got": "^10.6.0"
+    "got": "^11.8.6"
   },
   "scripts": {
     "clean": "rimraf ./dist",
@@ -40,7 +40,7 @@
   "version": "1.0.5",
   "devDependencies": {
     "@types/node": "10.17.19",
-    "typescript": "^3.8.3",
+    "typescript": "^4.1.6",
     "rimraf": "^3.0.2",
     "homebridge": "^1.0.4"
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "git+https://github.com/MTrinkiesJr/homebridge-glances.git"
   },
   "name": "homebridge-glances",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "devDependencies": {
     "@types/node": "10.17.19",
     "typescript": "^4.1.6",

--- a/src/Handler/CpuHandler.ts
+++ b/src/Handler/CpuHandler.ts
@@ -41,6 +41,14 @@ export class CpuHandler extends HandlerBase {
             if (response.statusCode == 200) {
                 return Promise.resolve(JSON.parse(response.body) as CpuInfo)
             }
+            // Check for glances version 3 api
+            if (response.statusCode == 404) {
+              this.log.info("CPUHandler: v4 endpoint not found, falling back to v3");
+              let responsev3 = await got('http://' + this.hostname + ':' + this.port + '/api/3/cpu');
+              if (responsev3.statusCode === 200) {
+                return Promise.resolve(JSON.parse(responsev3.body) as CpuInfo);
+              }
+            }
         } catch (error) {
             this.log.error("CpHandler: Failed request: '" + error + "'")
         }

--- a/src/Handler/CpuHandler.ts
+++ b/src/Handler/CpuHandler.ts
@@ -36,7 +36,7 @@ export class CpuHandler extends HandlerBase {
         cpuInfo = {} as CpuInfo;
 
         try {
-            let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/cpu');
+            let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/cpu', { throwHttpErrors: false });
 
             if (response.statusCode == 200) {
                 return Promise.resolve(JSON.parse(response.body) as CpuInfo)

--- a/src/Handler/CpuHandler.ts
+++ b/src/Handler/CpuHandler.ts
@@ -36,7 +36,7 @@ export class CpuHandler extends HandlerBase {
         cpuInfo = {} as CpuInfo;
 
         try {
-            let response = await got('http://' + this.hostname + ':' + this.port + '/api/3/cpu');
+            let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/cpu');
 
             if (response.statusCode == 200) {
                 return Promise.resolve(JSON.parse(response.body) as CpuInfo)

--- a/src/Handler/CpuHandler.ts
+++ b/src/Handler/CpuHandler.ts
@@ -43,7 +43,7 @@ export class CpuHandler extends HandlerBase {
             }
             // Check for glances version 3 api
             if (response.statusCode == 404) {
-              this.log.info("CPUHandler: v4 endpoint not found, falling back to v3");
+              this.log.debug("CPUHandler: v4 endpoint not found, falling back to v3");
               let responsev3 = await got('http://' + this.hostname + ':' + this.port + '/api/3/cpu');
               if (responsev3.statusCode === 200) {
                 return Promise.resolve(JSON.parse(responsev3.body) as CpuInfo);

--- a/src/Handler/HandlerBase.ts
+++ b/src/Handler/HandlerBase.ts
@@ -26,7 +26,7 @@ export abstract class HandlerBase {
         this.api = api;
     }
 
-    abstract async getServices(): Promise<BaseAccessory[]>
+    abstract getServices(): Promise<BaseAccessory[]>
 
-    abstract async updateServices() : Promise<void>;
+    abstract updateServices() : Promise<void>;
 }

--- a/src/Handler/MemoryHandler.ts
+++ b/src/Handler/MemoryHandler.ts
@@ -34,7 +34,7 @@ export class MemoryHandler extends HandlerBase {
         memoryInfo = {} as MemoryInfo;
 
         try {
-            let response = await got('http://' + this.hostname + ':' + this.port + '/api/3/mem');
+            let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/mem');
 
             if (response.statusCode) {
                 return Promise.resolve(JSON.parse(response.body) as MemoryInfo);

--- a/src/Handler/MemoryHandler.ts
+++ b/src/Handler/MemoryHandler.ts
@@ -36,8 +36,16 @@ export class MemoryHandler extends HandlerBase {
         try {
             let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/mem');
 
-            if (response.statusCode) {
+            if (response.statusCode == 200) {
                 return Promise.resolve(JSON.parse(response.body) as MemoryInfo);
+            }
+            // Check for glances version 3 api
+            if (response.statusCode == 404) {
+                this.log.info("MemoryHandler: v4 endpoint not found, falling back to v3");
+              let responsev3 = await got('http://' + this.hostname + ':' + this.port + '/api/3/mem');
+              if (responsev3.statusCode === 200) {
+                return Promise.resolve(JSON.parse(responsev3.body) as MemoryInfo);
+              }
             }
         } catch (error) {
             this.log.error("MemoryHandler: Failed request: '" + error + "'")

--- a/src/Handler/MemoryHandler.ts
+++ b/src/Handler/MemoryHandler.ts
@@ -34,7 +34,7 @@ export class MemoryHandler extends HandlerBase {
         memoryInfo = {} as MemoryInfo;
 
         try {
-            let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/mem');
+            let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/mem', { throwHttpErrors: false });
 
             if (response.statusCode == 200) {
                 return Promise.resolve(JSON.parse(response.body) as MemoryInfo);

--- a/src/Handler/MemoryHandler.ts
+++ b/src/Handler/MemoryHandler.ts
@@ -41,7 +41,7 @@ export class MemoryHandler extends HandlerBase {
             }
             // Check for glances version 3 api
             if (response.statusCode == 404) {
-                this.log.info("MemoryHandler: v4 endpoint not found, falling back to v3");
+                this.log.debug("MemoryHandler: v4 endpoint not found, falling back to v3");
               let responsev3 = await got('http://' + this.hostname + ':' + this.port + '/api/3/mem');
               if (responsev3.statusCode === 200) {
                 return Promise.resolve(JSON.parse(responsev3.body) as MemoryInfo);

--- a/src/Handler/SensorsHandler.ts
+++ b/src/Handler/SensorsHandler.ts
@@ -49,7 +49,7 @@ export class SensorsHandler extends HandlerBase {
               this.log.debug("SensorHandler: v4 endpoint not found, falling back to v3");
               let responsev3 = await got('http://' + this.hostname + ':' + this.port + '/api/3/sensors');
               if (responsev3.statusCode === 200) {
-                return Promise.resolve([]);
+                return Promise.resolve(JSON.parse(response.body) as SensorInfo[]);
               }
             }            
         } catch (error) {

--- a/src/Handler/SensorsHandler.ts
+++ b/src/Handler/SensorsHandler.ts
@@ -39,7 +39,7 @@ export class SensorsHandler extends HandlerBase {
 
     private async getSensors(): Promise<SensorInfo[]> {
         try {
-            let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/sensors');
+            let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/sensors', { throwHttpErrors: false });
 
             if (response.statusCode == 200) {
                 return Promise.resolve(JSON.parse(response.body) as SensorInfo[])

--- a/src/Handler/SensorsHandler.ts
+++ b/src/Handler/SensorsHandler.ts
@@ -49,7 +49,7 @@ export class SensorsHandler extends HandlerBase {
               this.log.debug("SensorHandler: v4 endpoint not found, falling back to v3");
               let responsev3 = await got('http://' + this.hostname + ':' + this.port + '/api/3/sensors');
               if (responsev3.statusCode === 200) {
-                return Promise.resolve(JSON.parse(response.body) as SensorInfo[]);
+                return Promise.resolve(JSON.parse(responsev3.body) as SensorInfo[]);
               }
             }            
         } catch (error) {

--- a/src/Handler/SensorsHandler.ts
+++ b/src/Handler/SensorsHandler.ts
@@ -46,7 +46,7 @@ export class SensorsHandler extends HandlerBase {
             }
             // Check for glances version 3 api
             if (response.statusCode == 404) {
-              this.log.info("SensorHandler: v4 endpoint not found, falling back to v3");
+              this.log.debug("SensorHandler: v4 endpoint not found, falling back to v3");
               let responsev3 = await got('http://' + this.hostname + ':' + this.port + '/api/3/sensors');
               if (responsev3.statusCode === 200) {
                 return Promise.resolve([]);

--- a/src/Handler/SensorsHandler.ts
+++ b/src/Handler/SensorsHandler.ts
@@ -38,7 +38,7 @@ export class SensorsHandler extends HandlerBase {
     }
 
     private async getSensors(): Promise<SensorInfo[]> {
-        let response = await got('http://' + this.hostname + ':' + this.port + '/api/3/sensors');
+        let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/sensors');
 
         try {
             if (response.statusCode == 200) {

--- a/src/Handler/SensorsHandler.ts
+++ b/src/Handler/SensorsHandler.ts
@@ -38,12 +38,20 @@ export class SensorsHandler extends HandlerBase {
     }
 
     private async getSensors(): Promise<SensorInfo[]> {
-        let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/sensors');
-
         try {
+            let response = await got('http://' + this.hostname + ':' + this.port + '/api/4/sensors');
+
             if (response.statusCode == 200) {
                 return Promise.resolve(JSON.parse(response.body) as SensorInfo[])
             }
+            // Check for glances version 3 api
+            if (response.statusCode == 404) {
+              this.log.info("SensorHandler: v4 endpoint not found, falling back to v3");
+              let responsev3 = await got('http://' + this.hostname + ':' + this.port + '/api/3/sensors');
+              if (responsev3.statusCode === 200) {
+                return Promise.resolve([]);
+              }
+            }            
         } catch (error) {
             this.log.error("SensorsHandler: Failed request: '" + error + "'")
         }


### PR DESCRIPTION
This adds support for the glances v4 api, which works similarly to the v3 api in respect to this plugin's use. 
This does add a failing call for every successful call for older glances installs still using v3 api, but its a quick fix. 

Longer term, I'm going to try to improve the logic to test for /api/v3/status and /api/v4/status, add an option to the plugin to override the test (in case proxys affect the http response checks) and modernize the plugin to be compatible with homebridge v2. 